### PR TITLE
dpkg provider has no versionnable feature

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -114,7 +114,7 @@ class aerospike::install {
     # For now only the packages that are not tarballs are installed.
     if $amc_pkg_provider != undef {
       ensure_packages('aerospike-amc', {
-        ensure   => $aerospike::amc_version,
+        ensure   => installed,
         provider => $amc_pkg_provider,
         source   => $amc_dest,
         require  => [ Archive[$amc_target_archive], ],

--- a/spec/classes/aerospike_spec.rb
+++ b/spec/classes/aerospike_spec.rb
@@ -351,7 +351,7 @@ describe 'aerospike' do
 
 				it do
           is_expected.to contain_package('aerospike-amc')\
-            .with_ensure('3.6.5')\
+            .with_ensure('installed')\
             .with_provider('dpkg')\
             .with_source('/tmp/aerospike-amc-community-3.6.5.all.x86_64.deb')
         end


### PR DESCRIPTION
We cannot use the version in ensure as dpkg doesn't have a versionnable feature.
