### PR TITLE
Cleanup of the metadata.json

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
-2016-02-25 Release 1.0.1:
+2016-03-02 Release 1.0.1:
 - Fixing documentation issues
+- Fixing metadata quality
 2016-02-17 Release 1.0.0
 - Initial version of the module

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "author": "TubeMogul Inc.",
   "summary": "Aerospike servers management via Puppet",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "source": "git@github.com:tubemogul/puppet-aerospike.git",
   "project_page": "https://github.com/tubemogul/puppet-aerospike",
   "issues_url": "https://github.com/tubemogul/puppet-aerospike/issues",
@@ -20,15 +20,11 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease":
       [
-        "6","8"
+        "6","7","8"
       ]
     }
   ],
   "dependencies": [
-    {
-      "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0"
-    },
     {
       "name": "puppet/archive",
       "version_requirement": ">= 0.0.1 < 1.0.0"


### PR DESCRIPTION
To fix the Metadata Quality error "Contains default stdlib dependency." and warning "Unrecognized license in metadata."
