### PR TITLE
fix errors when installing dependencies for AMC

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -69,7 +69,7 @@ class aerospike::install {
         $amc_extract = false
         $amc_target_archive = "${aerospike::amc_download_dir}/aerospike-amc-${aerospike::edition}-${aerospike::amc_version}${amc_pkg_extension}"
         $amc_dest = $amc_target_archive
-        $bcrypt_os_packages  = ['build-essential','python-dev','libffi-dev']
+        $pip_os_packages  = ['build-essential', 'python-dev', 'libffi-dev', 'libssl-dev']
       }
       'RedHat': {
         $amc_pkg_extension = '-el5.x86_64.rpm'
@@ -77,7 +77,7 @@ class aerospike::install {
         $amc_extract = false
         $amc_target_archive = "${aerospike::amc_download_dir}/aerospike-amc-${aerospike::edition}-${aerospike::amc_version}${amc_pkg_extension}"
         $amc_dest = $amc_target_archive
-        $bcrypt_os_packages  = ['gcc', 'libffi-devel', 'python-devel']
+        $pip_os_packages  = ['gcc', 'libffi-devel', 'python-devel', 'openssl-devel']
       }
       default : {
         $amc_pkg_extension ='.tar.gz'
@@ -85,7 +85,7 @@ class aerospike::install {
         $amc_extract = true
         $amc_target_archive = "${aerospike::amc_download_dir}/aerospike-amc-${aerospike::edition}-${aerospike::amc_version}${amc_pkg_extension}"
         $amc_dest = "${aerospike::amc_download_dir}/aerospike-amc-${aerospike::edition}-${aerospike::amc_version}"
-        $bcrypt_os_packages  = ['gcc', 'libffi-devel', 'python-devel']
+        $pip_os_packages  = ['gcc', 'libffi-devel', 'python-devel', 'openssl-devel']
       }
     }
 
@@ -95,19 +95,26 @@ class aerospike::install {
       default => $aerospike::amc_download_url,
     }
 
-    $os_packages  = ['python-pip', 'ansible']
-    $pip_packages = ['markupsafe','paramiko','ecdsa','pycrypto']
+    # Install pip without pip, see https://pip.pypa.io/en/stable/installing/
+    exec { 'bootstrap pip':
+      command => '/usr/bin/curl https://bootstrap.pypa.io/get-pip.py | python',
+      creates => '/usr/local/bin/pip',
+    }
+    file { 'pip-python':
+      ensure  => link,
+      path    => '/usr/bin/pip-python',
+      target  => '/usr/bin/pip',
+      require => Exec['bootstrap pip'],
+    }
+
+    $os_packages  = ['ansible']
+    $pip_packages = ['markupsafe', 'paramiko', 'ecdsa', 'pycrypto', 'bcrypt']
     ensure_packages($os_packages, { ensure => installed, } )
+    ensure_packages($pip_os_packages, { ensure => installed, } )
     ensure_packages($pip_packages, {
       ensure   => installed,
       provider => 'pip',
-      require  => [ Package['python-pip'], ],
-    })
-    ensure_packages($bcrypt_os_packages, { ensure => installed, } )
-    ensure_packages('bcrypt', {
-      ensure   => installed,
-      provider => 'pip',
-      require  => [ Package[$bcrypt_os_packages], Package['python-pip'], ],
+      require  => [ Package[$pip_os_packages], Exec['bootstrap pip'], ],
     })
     archive { $amc_target_archive:
       ensure       => present,

--- a/spec/classes/aerospike_spec.rb
+++ b/spec/classes/aerospike_spec.rb
@@ -328,13 +328,15 @@ describe 'aerospike' do
 				}}
 
 				# Tests related to the aerospike::install class
-        it { is_expected.to contain_package('python-pip').with_ensure('installed').that_comes_before('Package[bcrypt]') }
+        it { is_expected.to contain_exec('bootstrap pip').with_creates('/usr/local/bin/pip').that_comes_before('Package[bcrypt]') }
         it { is_expected.to contain_package('ansible').with_ensure('installed') }
 
         it { is_expected.to contain_package('markupsafe').with_ensure('installed').with_provider('pip') }
-        it { is_expected.to contain_package('paramiko').with_ensure('installed').with_provider('pip') }
         it { is_expected.to contain_package('ecdsa').with_ensure('installed').with_provider('pip') }
         it { is_expected.to contain_package('pycrypto').with_ensure('installed').with_provider('pip') }
+
+        it { is_expected.to contain_package('libssl-dev').with_ensure('installed').that_comes_before('Package[paramiko]') }
+        it { is_expected.to contain_package('paramiko').with_ensure('installed').with_provider('pip') }
 
         it { is_expected.to contain_package('build-essential').with_ensure('installed').that_comes_before('Package[bcrypt]') }
         it { is_expected.to contain_package('python-dev').with_ensure('installed').that_comes_before('Package[bcrypt]') }

--- a/spec/classes/aerospike_spec.rb
+++ b/spec/classes/aerospike_spec.rb
@@ -328,15 +328,13 @@ describe 'aerospike' do
 				}}
 
 				# Tests related to the aerospike::install class
-        it { is_expected.to contain_exec('bootstrap pip').with_creates('/usr/local/bin/pip').that_comes_before('Package[bcrypt]') }
+        it { is_expected.to contain_package('python-pip').with_ensure('installed').that_comes_before('Package[bcrypt]') }
         it { is_expected.to contain_package('ansible').with_ensure('installed') }
+        it { is_expected.to contain_package('python-paramiko').with_ensure('installed') }
 
         it { is_expected.to contain_package('markupsafe').with_ensure('installed').with_provider('pip') }
         it { is_expected.to contain_package('ecdsa').with_ensure('installed').with_provider('pip') }
         it { is_expected.to contain_package('pycrypto').with_ensure('installed').with_provider('pip') }
-
-        it { is_expected.to contain_package('libssl-dev').with_ensure('installed').that_comes_before('Package[paramiko]') }
-        it { is_expected.to contain_package('paramiko').with_ensure('installed').with_provider('pip') }
 
         it { is_expected.to contain_package('build-essential').with_ensure('installed').that_comes_before('Package[bcrypt]') }
         it { is_expected.to contain_package('python-dev').with_ensure('installed').that_comes_before('Package[bcrypt]') }
@@ -355,7 +353,7 @@ describe 'aerospike' do
 
 				it do
           is_expected.to contain_package('aerospike-amc-community')\
-            .with_ensure('installed')\
+            .with_ensure('latest')\
             .with_provider('dpkg')\
             .with_source('/tmp/aerospike-amc-community-3.6.5.all.x86_64.deb')
         end


### PR DESCRIPTION
Errors when installing dependencies for AMC on Ubuntu Trusty:

1.**pycrypto**

`==> ae: Error: Execution of '/usr/bin/pip install -q pycrypto' returned 1: Command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/pycrypto/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-wWUhhK-record/install-record.txt --single-version-externally-managed --compile failed with error code 1 in /tmp/pip_build_root/pycrypto
==> ae: Storing debug log for failure in /root/.pip/pip.log`

Fix: should be installed '_python-dev_ first.

2.**paramiko**

`==> ae: Error: Execution of '/usr/bin/pip install -q paramiko' returned 1: Command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/cryptography/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-Dzsamp-record/install-record.txt --single-version-externally-managed --compile failed with error code 1 in /tmp/pip_build_root/cryptography
==> ae: Storing debug log for failure in /root/.pip/pip.log`

Fix:
- should be installed 'libffi-dev' and 'libssl-dev' first.
- **paramiko** has dependency _cryptography_ which installs another dependency _setuptools_. After that, '_pip freeze_' won’t be work:

```
# pip freeze
Exception:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/pip/basecommand.py", line 122, in main
    status = self.run(options, args)
  File "/usr/lib/python2.7/dist-packages/pip/commands/freeze.py", line 74, in run
    req = pip.FrozenRequirement.from_dist(dist, dependency_links, find_tags=find_tags)
  File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 286, in from_dist
    assert len(specs) == 1 and specs[0][0] == '=='
AssertionError

Storing debug log for failure in /root/.pip/pip.log
```

the reason: for _setuptools_ need more newer version of pip (in Ubuntu Trusty the latest version: _1.5.4_).
To fix this: should be installed one of the latest version of pip. In this case, no reason install pip from Ubuntu repo and then upgrade it. More good way, install the latest version directly from pip repo by '_get-pip.py_' (see https://pip.pypa.io/en/stable/installing/).

Also, as for '_pycrypto_' and '_paramiko_' should be installed part of the dependencies from _$bcrypt_os_packages_, therefore, '_bcrypt_' was added in _$pip_packages_ and _$bcrypt_os_packages_ renamed to _$pip_os_packages_.
