### PR TITLE
Fixing puppet-lint "WARNING: variable not enclosed in {} on line 10"

### DIFF
--- a/manifests/xdr_credentials_file.pp
+++ b/manifests/xdr_credentials_file.pp
@@ -7,7 +7,7 @@ define aerospike::xdr_credentials_file (
 ) {
   if ! empty($all_xdr_credentials) {
     $dc_credentials = $all_xdr_credentials[$name]
-    file { "/etc/aerospike/security-credentials_$name.txt":
+    file { "/etc/aerospike/security-credentials_${name}.txt":
       ensure  => present,
       content => template('aerospike/security-credentials.conf.erb'),
       mode    => '0600',


### PR DESCRIPTION
This gets your score down on the forge :(
We need to make sure all the puppet-lint warnings (out of the "line too long") are fixed next time! :)
