### PR TITLE
added notify to refresh service after creating/modifying file

### DIFF
--- a/manifests/xdr_credentials_file.pp
+++ b/manifests/xdr_credentials_file.pp
@@ -13,6 +13,7 @@ define aerospike::xdr_credentials_file (
       mode    => '0600',
       owner   => $owner,
       group   => $group,
+      notify  => Service['aerospike'],
     }
   }
 


### PR DESCRIPTION
Aerospike should restart after creating/modifying file.
Also this fixes the issue Aerospike restart before creating file.

Before changes:

> Notice: /Stage[main]/Aerospike::Config/File[/etc/aerospike/aerospike.conf]/ensure: defined content as '{md5}a14670b6c479478565d01c308cc267cb'
> Info: Class[Aerospike::Config]: Scheduling refresh of Class[Aerospike::Service]
> Info: Class[Aerospike::Service]: Scheduling refresh of Service[aerospike]
> Notice: /Stage[main]/Aerospike::Service/Service[aerospike]: Triggered 'refresh' from 1 events
> Notice: /Stage[main]/Aerospike/Aerospike::Xdr_credentials_file[DC1]/File[/etc/aerospike/security-credentials_DC1.txt]/ensure: created
> Notice: Finished catalog run in 26.20 seconds

After changes (adding notify):

> Notice: /Stage[main]/Aerospike::Config/File[/etc/aerospike/aerospike.conf]/ensure: defined content as '{md5}a14670b6c479478565d01c308cc267cb'
> Info: Class[Aerospike::Config]: Scheduling refresh of Class[Aerospike::Service]
> Info: Class[Aerospike::Service]: Scheduling refresh of Service[aerospike]
> Notice: /Stage[main]/Aerospike/Aerospike::Xdr_credentials_file[IAD]/File[/etc/aerospike/security-credentials_IAD.txt]/ensure: created
> Info: /Stage[main]/Aerospike/Aerospike::Xdr_credentials_file[IAD]/File[/etc/aerospike/security-credentials_IAD.txt]: Scheduling refresh of Service[aerospike]
> Notice: /Stage[main]/Aerospike::Service/Service[aerospike]: Triggered 'refresh' from 2 events
> Notice: Finished catalog run in 25.21 seconds
