### PR TITLE
Fixing Json_pure dependency problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
+  gem "json_pure", '2.0.1' if RUBY_VERSION < '2.0'
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.4'
   gem "rspec-core", '< 3.2' if RUBY_VERSION < '1.9'


### PR DESCRIPTION
The json_pure gem dropped ruby <2.0 compatibility in version 2.0.2.
Fixing the Gemfile to take that in account.
