### PR TITLE
Fix multi-datacenter XDR for namespaces

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
   "dependencies": [
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 0.0.1 < 1.0.0"
+      "version_requirement": ">= 0.0.1 < 2.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/aerospike_spec.rb
+++ b/spec/classes/aerospike_spec.rb
@@ -316,6 +316,55 @@ describe 'aerospike' do
         it { should contain_Aerospike__Xdr_credentials_file('DC1') }
       end
 
+
+      # #####################################################################
+      # Tests multiple datacenter replication for a given namespace
+      # #####################################################################
+      describe "Tests multiple datacenter replication for a given namespace on #{osfamily}" do
+        let(:params) {{
+          :config_ns                  => {
+            'foo'                     => {
+              'enable-xdr'            => true,
+              'xdr-remote-datacenter' => [ 'DC1', 'DC2' ],
+            },
+          },
+          :config_xdr            => {
+            'enable-xdr'         => true,
+            'xdr-digestlog-path' => '/opt/aerospike/digestlog 100G',
+            'xdr-errorlog-path'  => '/var/log/aerospike/asxdr.log',
+            'xdr-pidfile'        => '/var/run/aerospike/asxdr.pid',
+            'local-node-port'    => 4000,
+            'xdr-info-port'      => 3004,
+            'datacenter DC1'     => [
+              'dc-node-address-port 172.1.1.100 3000',
+            ],
+            'datacenter DC2' => [
+              'dc-node-address-port 172.2.2.100 3000',
+            ],
+          },
+        }}
+        let(:facts) {{
+          :osfamily => osfamily,
+        }}
+
+        it { should compile.with_all_deps }
+        it do
+          is_expected.to create_file('/etc/aerospike/aerospike.conf')\
+            .with_content(/^\s*namespace foo {$/)\
+            .with_content(/^\s*enable-xdr true$/)\
+            .with_content(/^\s*xdr-remote-datacenter DC1$/)\
+            .with_content(/^\s*xdr-remote-datacenter DC2$/)\
+            .with_content(/^\s*xdr-digestlog-path \/opt\/aerospike\/digestlog 100G$/)\
+            .with_content(/^\s*xdr-errorlog-path \/var\/log\/aerospike\/asxdr.log$/)\
+            .with_content(/^\s*xdr-pidfile \/var\/run\/aerospike\/asxdr.pid$/)\
+            .with_content(/^\s*local-node-port 4000$/)\
+            .with_content(/^\s*xdr-info-port 3004$/)\
+            .with_content(/^\s*datacenter DC1 {$/)\
+            .with_content(/^\s*dc-node-address-port 172.1.1.100 3000$/)\
+            .with_content(/^\s*datacenter DC2 {$/)\
+            .with_content(/^\s*dc-node-address-port 172.2.2.100 3000$/)
+        end
+      end
     end
   end
 

--- a/templates/aerospike.conf.erb
+++ b/templates/aerospike.conf.erb
@@ -59,11 +59,17 @@ cluster {
 # namespace context: <%= ns %>
 namespace <%= ns %> {
 <%  cfg.sort.each do |item_k,item_v|
-      if item_v.is_a?(Array) -%>
+  if item_v.is_a?(Array)
+    if item_k == 'xdr-remote-datacenter'
+       item_v.sort.each do |prop| -%>
+  <%= item_k %> <%= prop %>
+<%     end
+    else -%>
   <%= item_k %> {
-<%       item_v.sort.each do |prop| -%>
+<%     item_v.sort.each do |prop| -%>
     <%= prop %>
-<%       end -%>
+<%     end
+    end -%>
   }
 <%     else -%>
   <%= item_k %> <%= item_v %>


### PR DESCRIPTION
When doing multi-datacenter replication of one namespace, we end up defining several times the key `xdr-remote-datacenter`, which ends up overwriting each-other.
This pull-request fixes that.
Also included in this PR:
- a full real-life multi-datacenter replication example for XDR with security enabled
- a bump of upper version for the archive module
