### PR TITLE
Adding ways to not manage the service and not restart on config change

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,4 +13,14 @@ class aerospike::config {
     group   => $aerospike::system_group,
   }
 
+  # If 'aerospike::config_xdr_credentials' defined - create file(s) with credentials for XDR
+  if ! empty($aerospike::config_xdr_credentials) {
+    $xdr_rDCs = keys($aerospike::config_xdr_credentials)
+    aerospike::xdr_credentials_file {
+      $xdr_rDCs:
+        all_xdr_credentials => $aerospike::config_xdr_credentials,
+        owner               => $aerospike::system_user,
+        group               => $aerospike::system_group,
+    }
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,11 +5,13 @@
 #
 class aerospike::service {
 
-  service {'aerospike':
-    ensure     => $aerospike::service_status,
-    hasrestart => true,
-    hasstatus  => true,
-    provider   => 'init',
+  if $aerospike::manage_service {
+    service {'aerospike':
+      ensure     => $aerospike::service_status,
+      hasrestart => true,
+      hasstatus  => true,
+      provider   => 'init',
+    }
   }
 
   if $aerospike::amc_manage_service {

--- a/manifests/xdr_credentials_file.pp
+++ b/manifests/xdr_credentials_file.pp
@@ -1,5 +1,9 @@
 # == Define: aerospike::xdr_credentials_file
 #
+# We don't notify the service from here as if we change the credential in
+# several files, the service would be restarted multiple times. The service is
+# restarted only once after any change in the aerospike::config class.
+#
 define aerospike::xdr_credentials_file (
   $all_xdr_credentials,
   $owner = 'root',
@@ -13,8 +17,6 @@ define aerospike::xdr_credentials_file (
       mode    => '0600',
       owner   => $owner,
       group   => $group,
-      notify  => Service['aerospike'],
     }
   }
-
 }

--- a/spec/defines/xdr_credentials_file_spec.rb
+++ b/spec/defines/xdr_credentials_file_spec.rb
@@ -16,10 +16,10 @@ describe 'aerospike::xdr_credentials_file' do
         .with_mode('0600')\
         .with_owner('root')\
         .with_group('root')\
-        .with_notify('Service[aerospike]')\
         .with_content(/^credentials$/)\
         .with_content(/username xdr_user_DC1$/)\
-        .with_content(/password xdr_password_DC1$/)
+        .with_content(/password xdr_password_DC1$/)\
+        .without_notify
     end
   end
 


### PR DESCRIPTION
This PR contains 2 new parameters with the corresponding documentation:
- `manage_service` to not manage the aerospike service at all
- `restart_on_config_change` to manage the service but not restart on config change

Also, the change on the call of the `aerospike::xdr_credentials_file` has been moved from the init.pp to the config.pp as it makes more sense and avoids to restart 10 times the service if 10 credentials files have been modified in a single puppet run. No more notify directly in the define, but on the whole `aerospike::config` class so if one or more configs have been changed, the refresh of the service is called only once (if both `manage_service` and `restart_on_config_change` are set to true).

Also changed some defaults as the module as it is now is made more for aerospike 3.8.1+ than for aerospike 3.7.
