### PR TITLE
Fix incorrect configuration generation when using multiple XDR target

### DIFF
--- a/templates/aerospike.conf.erb
+++ b/templates/aerospike.conf.erb
@@ -68,9 +68,9 @@ namespace <%= ns %> {
   <%= item_k %> {
 <%     item_v.sort.each do |prop| -%>
     <%= prop %>
-<%     end
-    end -%>
+<%     end -%>
   }
+<%   end -%>
 <%     else -%>
   <%= item_k %> <%= item_v %>
 <%     end


### PR DESCRIPTION
Fix incorrect configuration generation when using multiple XDR targets for a namespace
