### PR TITLE
Service provider docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ spec/fixtures
 .vagrant
 .bundle
 vendor
+.ruby-version
+Gemfile.lock

--- a/README.markdown
+++ b/README.markdown
@@ -680,6 +680,12 @@ will still be configured.
 
 Default: `true`
 
+##### `service_provider`
+
+String defining mechanism for managing service. See [Puppet docs](https://docs.puppet.com/puppet/latest/types/service.html#service-attribute-provider) for supported values.
+
+Default: `undef` (Puppet will determine appropriate value)
+
 ##### `restart_on_config_change`
 
 Boolean indicating whether or not you want to restart the aerospike service
@@ -949,7 +955,7 @@ http://www.aerospike.com/docs/operations/configure/cross-datacenter/
 ##### `config_xdr_credentials`
 
 Configuration parameters to define the xdr credentials (user/password) for the remote cluster in the
-separate secured file when security enabled. 
+separate secured file when security enabled.
 
 This parameter is a hash table with:
   * the property name as key

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,7 @@ class aerospike (
   $config_xdr_credentials = {},
   $service_status         = 'running',
   $service_enable         = true,
-  $service_provider       = 'init',
+  $service_provider       = undef,
   $amc_install            = false,
   $amc_version            = '3.6.6',
   $amc_download_dir       = '/usr/local/src',
@@ -88,7 +88,6 @@ class aerospike (
     $system_user,
     $system_group,
     $service_status,
-    $service_provider,
     $amc_version,
     $amc_download_dir,
     $amc_service_status,
@@ -115,6 +114,7 @@ class aerospike (
     $config_xdr,
     $config_xdr_credentials,
   )
+  if $service_provider { validate_string($service_provider) }
   if ! is_integer($system_uid) { fail("invalid ${system_uid} provided") }
   if ! is_integer($system_gid) { fail("invalid ${system_gid} provided") }
 

--- a/spec/classes/aerospike_spec.rb
+++ b/spec/classes/aerospike_spec.rb
@@ -78,17 +78,18 @@ describe 'aerospike' do
       # #####################################################################
       describe "aerospike class with all parameters (except custom url) on #{osfamily}" do
         let(:params) {{
-          :version        => '3.8.3',
-          :download_dir   => '/tmp',
-          :remove_archive => true,
-          :edition        => 'enterprise',
-          :target_os_tag  => 'ubuntu12.04',
-          :download_user  => 'dummy_user',
-          :download_pass  => 'dummy_password',
-          :system_user    => 'as_user',
-          :system_uid     => 511,
-          :system_group   => 'as_group',
-          :system_gid     => 512,
+          :version          => '3.8.3',
+          :download_dir     => '/tmp',
+          :remove_archive   => true,
+          :edition          => 'enterprise',
+          :target_os_tag    => 'ubuntu12.04',
+          :download_user    => 'dummy_user',
+          :download_pass    => 'dummy_password',
+          :system_user      => 'as_user',
+          :system_uid       => 511,
+          :system_group     => 'as_group',
+          :system_gid       => 512,
+          :service_provider => 'init',
           :config_service => {
             'paxos-single-replica-limit'    => 2,
             'pidfile'                       => '/run/aerospike/asd.pid',
@@ -442,7 +443,8 @@ describe 'aerospike' do
       # change the defautl version.
 			describe "aerospike class without any parameters on #{osfamily}" do
 				let(:params) {{
-					:amc_version => '3.6.6',
+					:amc_version      => '3.6.6',
+          :service_provider => 'init',
         }}
 				let(:facts) {{
 					:osfamily => osfamily,
@@ -516,8 +518,7 @@ describe 'aerospike' do
             .with_ensure('stopped')\
             .with_enable(true)\
             .with_hasrestart(true)\
-            .with_hasstatus(true)\
-            .with_provider('init')
+            .with_hasstatus(true)
         end
 			end
 		end


### PR DESCRIPTION
Originally I wanted to add just the documentation. Then I came up with few more modifications. Service provider is not set, unless needed. Such approach is also recommended by Puppet docs:

> You will seldom need to specify this — Puppet will usually discover the appropriate provider for your platform.

If you really want to have some default value, we should add something like `params.pp` with appropriate service provider for each supported distribution.