### PR TITLE
Use non-interactive installation on Debian

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@ class aerospike (
   $target_os_tag            = 'ubuntu14.04',
   $download_user            = undef,
   $download_pass            = undef,
+  $asinstall_params         = undef,
   $system_user              = 'root',
   $system_uid               = 0,
   $system_group             = 'root',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -36,7 +36,7 @@ class aerospike::install {
   case $::osfamily {
     'Debian': {
       exec { 'aerospike-install-server':
-        command     => "${dest}/asinstall --force-confold",
+        command     => "${dest}/asinstall --force-confold -i",
         cwd         => $dest,
         refreshonly => true,
         require     => Archive["${dest}.tgz"],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,11 +30,26 @@ class aerospike::install {
     extract_path => $aerospike::download_dir,
     creates      => $dest,
     cleanup      => $aerospike::remove_archive,
-  } ~>
-  exec { 'aerospike-install-server':
-    command     => "${dest}/asinstall",
-    cwd         => $dest,
-    refreshonly => true,
+    notify       => Exec['aerospike-install-server'],
+  }
+
+  case $::osfamily {
+    'Debian': {
+      exec { 'aerospike-install-server':
+        command     => "${dest}/asinstall --force-confold",
+        cwd         => $dest,
+        refreshonly => true,
+        require     => Archive["${dest}.tgz"],
+      }
+    }
+    default : {
+      exec { 'aerospike-install-server':
+        command     => "${dest}/asinstall",
+        cwd         => $dest,
+        refreshonly => true,
+        require     => Archive["${dest}.tgz"],
+      }
+    }
   }
 
   # #######################################

--- a/spec/classes/aerospike_spec.rb
+++ b/spec/classes/aerospike_spec.rb
@@ -66,7 +66,8 @@ describe 'aerospike' do
             .with_extract(true)\
             .with_extract_path('/usr/local/src')\
             .with_creates('/usr/local/src/aerospike-server-enterprise-3.8.3-ubuntu14.04')\
-            .with_cleanup(false)
+            .with_cleanup(false)\
+            .that_notifies('Exec[aerospike-install-server]')
         end
 
         it { is_expected.to contain_exec('aerospike-install-server') }
@@ -194,7 +195,8 @@ describe 'aerospike' do
             .with_extract(true)\
             .with_extract_path('/tmp')\
             .with_creates('/tmp/aerospike-server-enterprise-3.8.3-ubuntu12.04')\
-            .with_cleanup(true)
+            .with_cleanup(true)\
+            .that_notifies('Exec[aerospike-install-server]')
         end
 
         it { is_expected.to contain_exec('aerospike-install-server') }


### PR DESCRIPTION
`asinstall` script supports passing extra arguments to `dpkg` that can be used to skip questions about Aerospike configuration files that are being overwritten (configuration file is managed by Puppet anyway).