### PR TITLE
Don't set UID and GID by default

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -656,7 +656,7 @@ Default: `root`
 
 UID of the OS user to be used by the service.
 
-Default: `0`
+Default: `undef` (number is assigned by the OS)
 
 ##### `system_group`
 
@@ -670,7 +670,7 @@ Default: `root`
 
 GID of the OS user to be used by the service.
 
-Default: `0`
+Default: `undef` (number is assigned by the OS)
 
 ##### `manage_service`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,9 +17,9 @@ class aerospike (
   $download_user            = undef,
   $download_pass            = undef,
   $system_user              = 'root',
-  $system_uid               = 0,
+  $system_uid               = undef,
   $system_group             = 'root',
-  $system_gid               = 0,
+  $system_gid               = undef,
   $manage_service           = true,
   $restart_on_config_change = true,
   $config_service           = {
@@ -115,8 +115,8 @@ class aerospike (
     $config_xdr,
     $config_xdr_credentials,
   )
-  if ! is_integer($system_uid) { fail("invalid ${system_uid} provided") }
-  if ! is_integer($system_gid) { fail("invalid ${system_gid} provided") }
+  if $system_uid and ! is_integer($system_uid) { fail("invalid ${system_uid} provided") }
+  if $system_gid and ! is_integer($system_gid) { fail("invalid ${system_gid} provided") }
 
   include '::aerospike::install'
   include '::aerospike::config'


### PR DESCRIPTION
Puppet user and group management doesn't always work as planned. Using `root` and `UID=0` can lead to resource duplication in case that `User[root]` is declared elsewhere in the catalogue. Having `undef` UID and GID would lead to the same result.