### PR TITLE
List stdlib as dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,11 +26,11 @@
   ],
   "dependencies": [
     {
-      "name": "puppet-archive",
+      "name": "puppet/archive",
       "version_requirement": ">= 0.0.1 < 2.0.0"
     },
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": ">= 2.2.1 < 5.0.0"
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -26,8 +26,12 @@
   ],
   "dependencies": [
     {
-      "name": "puppet/archive",
+      "name": "puppet-archive",
       "version_requirement": ">= 0.0.1 < 2.0.0"
+    },
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 2.2.1 < 5.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
`puppetlabs-stdlib` should be listed as module's dependency. The lower version bound was guessed by the first version where `is_integer` function appeared. 