### PR TITLE
Adding the support for the RedHat family in the metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Adding missing `stdlib` dependency to the `metadata.json`
 - A `aerospike::params` class has been added to hold the default values
 - Update `.gitignore` to ignore all version-dependent files
+- Adding the support for the RedHat OS family in the `metadata.json`
 
 ### Changed
 - The default values of `system_uid` and `system_gid` have been changed from 0

--- a/README.markdown
+++ b/README.markdown
@@ -1114,7 +1114,7 @@ namespace foo {
 ##Limitations
 
 This module has only been tested against Ubuntu 14.04, but it should work with
-the Debian family and the Red Hat servers.
+the Debian and the Red Hat family.
 
 ##Development
 

--- a/metadata.json
+++ b/metadata.json
@@ -22,6 +22,24 @@
       [
         "6","7","8"
       ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6", "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6", "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6", "7"
+      ]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
I got some feedback that people were using the module on RedHat, so adding the RedHat family to the metadata.json