### PR TITLE
Puppet archive version 1.3.0 is the last one compatible with puppet 3.x

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,8 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    archive: "git://github.com/puppet-community/puppet-archive.git"
+    archive:
+      repo: "git://github.com/voxpupuli/puppet-archive.git"
+      ref:  "v1.3.0"
   symlinks:
     aerospike: "#{source_dir}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Puppet archive version 1.3.0 is the last one compatible with puppet 3.x and
+  the last one compatible with this module for now. Changing the `.fixtures.yml`
+  to reflect that.
 
 ## [1.3.0] - 2017-01-30
 ### Added


### PR DESCRIPTION
Puppet archive version 1.3.0 is the last one compatible with puppet 3.x and the last one compatible with this module for now. Changing the `.fixtures.yml` to reflect that.