### PR TITLE
Fix tests + titles not showing up properly with new markdown parser

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@ require: rubocop-rspec
 AllCops:
   Include:
     - ./**/*.rb
+    - '**/Gemfile'
+    - '**/Guardfile'
+    - '**/Rakefile'
   Exclude:
     - files/**/*
     - vendor/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   the last one compatible with this module for now. Changing the `.fixtures.yml`
   to reflect that.
 
+### Fixed
+- Fixed some documentation cosmetics in the README
+- Fixed some rubocop complains
+- Fixed some gems dependencies with ruby 1.9
+
 ## [1.3.0] - 2017-01-30
 ### Added
 - New parameter: `asinstall_params`: sets extra parameters to the installer

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ group :test do
   gem 'rspec-core', '< 3.2.0' if RUBY_VERSION < '1.9'
   gem 'rspec-puppet'
   gem 'rspec-puppet-facts'
-  gem 'rubocop-rspec', :require => false if RUBY_VERSION >= '2.3.0'
+  gem 'rubocop-rspec', require: false if RUBY_VERSION >= '2.3.0'
   gem 'simplecov', '>= 0.11.0'
-  gem 'simplecov-console', if RUBY_VERSION < '2.0.0' then '< 0.4.0' end
+  gem 'simplecov-console'
 
   gem 'puppet-lint-absolute_classname-check'
   gem 'puppet-lint-classes_and_types_beginning_with_digits-check'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
   gem 'metadata-json-lint'
+  gem 'parallel_tests', '< 2.10.0' if RUBY_VERSION < '2.0.0'
   gem 'puppet', ENV['PUPPET_VERSION'] || '~> 4.0'
   gem 'puppetlabs_spec_helper'
   gem 'rake'

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,5 @@
 notification :off
 
-guard 'rake', :task => 'test' do
+guard 'rake', task: 'test' do
   watch(%r{^manifests\/(.+)\.pp$})
 end

--- a/README.markdown
+++ b/README.markdown
@@ -1111,12 +1111,12 @@ namespace foo {
 }
 ```
 
-##Limitations
+## Limitations
 
 This module has only been tested against Ubuntu 14.04, but it should work with
 the Debian and the Red Hat family.
 
-##Development
+## Development
 
 See the [CONTRIBUTING.md](https://github.com/tubemogul/puppet-aerospike/blob/master/CONTRIBUTING.md) file.
 

--- a/Rakefile
+++ b/Rakefile
@@ -18,14 +18,15 @@ end
 begin
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
-rescue LoadError
+rescue LoadError => e
+  puts "INFO: ignoring rubocop tasks as not installed #{e.message}"
 end
 
 exclude_paths = [
-  "bundle/**/*",
-  "pkg/**/*",
-  "vendor/**/*",
-  "spec/**/*",
+  'bundle/**/*',
+  'pkg/**/*',
+  'vendor/**/*',
+  'spec/**/*'
 ]
 
 # Coverage from puppetlabs-spec-helper requires rcov which
@@ -46,20 +47,15 @@ end
 
 PuppetSyntax.exclude_paths = exclude_paths
 
-desc "Run acceptance tests"
+desc 'Run acceptance tests'
 RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-desc "Populate CONTRIBUTORS file"
+desc 'Populate CONTRIBUTORS file'
 task :contributors do
-  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+  system('git log --format=\'%aN\' | sort -u > CONTRIBUTORS')
 end
 
-desc "Run syntax, lint, and spec tests."
-task :test => [
-  :metadata_lint,
-  :syntax,
-  :lint,
-  :spec,
-]
+desc 'Run syntax, lint, and spec tests.'
+task test: %w(metadata_lint syntax lint spec)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,12 +126,9 @@ class aerospike (
   include '::aerospike::service'
 
   if $manage_service and $restart_on_config_change {
-    Class['aerospike::config'] ~>
-    Class['aerospike::service']
+    Class['aerospike::config'] ~> Class['aerospike::service']
   }
 
-  Class['aerospike::install'] ->
-  Class['aerospike::config'] ->
-  Class['aerospike::service']
+  Class['aerospike::install'] -> Class['aerospike::config'] -> Class['aerospike::service']
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,8 +40,7 @@ class aerospike::install {
     extract_path => $aerospike::download_dir,
     creates      => $dest,
     cleanup      => $aerospike::remove_archive,
-  } ~>
-  exec { 'aerospike-install-server':
+  } ~> exec { 'aerospike-install-server':
     command     => "${dest}/asinstall ${_asinstall_params}",
     cwd         => $dest,
     refreshonly => true,


### PR DESCRIPTION
With the new markdown parser from GH the titles don't show up as a title if you don't put a space after the pound sign.
This PR fixes this and some rubocop tests failing because of new version and dependency on ruby 1.9.