### PR TITLE
Add support for heartbeat unicast

### DIFF
--- a/templates/aerospike.conf.erb
+++ b/templates/aerospike.conf.erb
@@ -41,9 +41,17 @@ network {
   }
 
   heartbeat {
-<% scope.lookupvar('aerospike::config_net_hb').sort.each do |k,v| -%>
-    <%= k %> <%= v %>
-<% end -%>
+<% scope.lookupvar('aerospike::config_net_hb').sort.each do |hb_k,hb_v|
+  if hb_v.is_a?(Array)
+    if hb_k == 'mesh-seed-address-port'
+      hb_v.sort.each do |prop| -%>
+    <%= hb_k %> <%= prop %>
+<%    end
+    end
+  else -%>
+    <%= hb_k %> <%= hb_v %>
+<% end
+  end -%>
   }
 }
 


### PR DESCRIPTION
This enables to add heartbeat unicast nodes into config section. If aerospike::config_net_hb key mesh-seed-address-port set as array with multiple hosts (["10.2.243.52 3002","10.2.243.53 3002","10.2.243.54 3002"]), this patch to get final correct config:

`
  heartbeat {
    address any
    interval 150
    mesh-seed-address-port 10.2.243.52 3002
    mesh-seed-address-port 10.2.243.53 3002
    mesh-seed-address-port 10.2.243.54 3002
    mode mesh
    port 3002
    timeout 10
  }
`