### PR TITLE
Fix Rubocop Style/PercentLiteralDelimiters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,4 +58,4 @@ task :contributors do
 end
 
 desc 'Run syntax, lint, and spec tests.'
-task test: %w(metadata_lint syntax lint spec)
+task test: %w[metadata_lint syntax lint spec]

--- a/spec/classes/aerospike_spec.rb
+++ b/spec/classes/aerospike_spec.rb
@@ -359,7 +359,7 @@ describe 'aerospike' do
           config_ns: {
             'foo' => {
               'enable-xdr'            => true,
-              'xdr-remote-datacenter' => %w(DC1 DC2)
+              'xdr-remote-datacenter' => %w[DC1 DC2]
             }
           },
           config_xdr: {


### PR DESCRIPTION
This PR fixes the following rubocop warnings/errors:
```
Running RuboCop...
Inspecting 9 files
C.....C..

Offenses:

Rakefile:61:12: C: Style/PercentLiteralDelimiters: %w-literals should be delimited by [ and ].  (https://github.com/bbatsov/ruby-style-guide#percent-literal-braces)
task test: %w(metadata_lint syntax lint spec)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/classes/aerospike_spec.rb:362:42: C: Style/PercentLiteralDelimiters: %w-literals should be delimited by [ and ].  (https://github.com/bbatsov/ruby-style-guide#percent-literal-braces)
              'xdr-remote-datacenter' => %w(DC1 DC2)
                                         ^^^^^^^^^^^

9 files inspected, 2 offenses detected
RuboCop failed!
```

Cc. @br0ch0n @alekseymykhailov @ynnt thx