### PR TITLE
remove ruby 1.9.3 from test suite, upgrade patch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,13 @@ before_install:
 script: 'bundle exec rake $CHECK'
 matrix:
   include:
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes CHECK=test
-  - rvm: 2.1.9
+  - rvm: 2.1.10
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES=yes CHECK=test
-  - rvm: 2.1.9
+  - rvm: 2.1.10
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES=yes CHECK=test
-  - rvm: 2.2.6
+  - rvm: 2.2.8
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES=yes CHECK=test
-  - rvm: 2.3.3
+  - rvm: 2.3.5
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES=yes CHECK=test
-  - rvm: 2.3.3
+  - rvm: 2.3.5
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES=yes CHECK=rubocop


### PR DESCRIPTION
Ruby 1.9.3 is 2 years beyond End Of Life, it's time to move on :)