### PR TITLE
Fix archive dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,7 @@
   "dependencies": [
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 0.0.1 < 2.0.0"
+      "version_requirement": ">= 0.5.1 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Support at least `puppet/archive` versions `2.x`.